### PR TITLE
Only call `process()` on data that exists

### DIFF
--- a/index.js
+++ b/index.js
@@ -18,6 +18,10 @@ function WPError () {
 }
 
 function process ( self, data ) {
+  if ( ! data ) { 
+    return;
+  }
+  
   if (typeof data === 'number') {
     setStatusCode( self, data );
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wp-error",
-  "version": "1.2.0",
+  "version": "1.3.0",
   "description": "Common logic to process WordPress.com API responses into JS Error objects",
   "main": "index.js",
   "scripts": {

--- a/test.js
+++ b/test.js
@@ -76,3 +76,10 @@ assert.equal(err.name, 'TakenError');
 assert.equal(err.message, 'Choose a different email address. This one is not available.');
 assert.equal(err.error, 'taken');
 assert.equal(err.status, 'error');
+
+// does not throw exception on empty input
+assert.doesNotThrow(function(){
+	new WPError(null);
+	new WPError(undefined);
+	new WPError({"name":"value"},null,undefined);
+});


### PR DESCRIPTION
While tracking down a `TypeError` being thrown, I discovered that the change in https://github.com/Automattic/wpcom-xhr-request/commit/ba5fcbea2e236cfa29874b6de4e761ce250b2fac started using the `WPError` to report errors, but on a 404 it appears to send a `null` `body`, which causes this to fail when it tries to access `null.status_code` in line 27.

This change would simply early-abort if `process()` gets called with `undefined` or `null` data.

cc: @TooTallNate 
